### PR TITLE
Replace outdated links with internet archive links

### DIFF
--- a/zsh-lovers.1.txt
+++ b/zsh-lovers.1.txt
@@ -1447,8 +1447,8 @@ ZSH-FAQ::
     *https://zsh.sourceforge.io/FAQ/zshfaq.html[]*
 Userguide::
     *https://zsh.sourceforge.io/Guide/[]*
-ZSH-Wiki::
-    *http://zshwiki.org/home/[]*
+ZSH-Wiki (Archived link)::
+    *http://zshwiki.org/home/[https://web.archive.org/web/20160304135622/http://zshwiki.org/home/]*
 Mouse-Support ;)::
     *http://stchaz.free.fr/mouse.zsh[]*
 ZSH Prompt introduction::
@@ -1459,8 +1459,8 @@ ft's zsh configuration::
     *https://gitlab.com/ft/etc-zsh[]*
 Adam's ZSH page::
     *http://www.adamspiers.org/computing/zsh/[]*
-Zzappers Best of ZSH Tips::
-    *http://www.rayninfo.co.uk/tips/zshtips.html[]*
+Zzappers Best of ZSH Tips (Archived link)::
+    *http://www.rayninfo.co.uk/tips/zshtips.html[https://web.archive.org/web/20190517011103/http://www.rayninfo.co.uk/tips/zshtips.html]*
 Zsh Webpage by Christian Schneider::
     *http://www.strcat.de/zsh/[]*
 The zsh-lovers webpage::


### PR DESCRIPTION
An attempt to preserve references to some very useful zsh resources. Obviously the archived links cannot be maintained or updated, but zsh's [README lists incompatibilities](https://github.com/zsh-users/zsh/blob/master/README#L34).

I would also like to add archived links for [@mika's pages](https://github.com/grml/zsh-lovers/commit/40d803d492f29a13ceb863a54492223424d7e883) but you removed them for a reason. Maybe archived links deserve a section marked "Obsolete; use at your own risk"?